### PR TITLE
replace `background_callback` with `hooks`

### DIFF
--- a/twyla/logging/handlers.py
+++ b/twyla/logging/handlers.py
@@ -14,7 +14,7 @@ session = FuturesSession()
 
 URL_BASE =  'https://logs-01.loggly.com/inputs/{token}/tag/{tag}'
 
-def bg_cb(sess, resp):
+def bg_cb(resp, *args, **kwargs):
     """ Don't do anything with the response """
     pass
 
@@ -34,7 +34,7 @@ class LogglyHTTPSHandler(logging.Handler):
         data = self.formatter.format(record)
         try:
             payload = json.dumps(data)
-            session.post(self.url, data=payload, background_callback=bg_cb)
+            session.post(self.url, data=payload, hooks={"response": bg_cb})
         except (KeyboardInterrupt, SystemExit):
             raise
         except:


### PR DESCRIPTION
`background_callback` is deprecated. This causes an infinite recursion as the warning tries to log, which triggers another warning, which tries to log... which triggers another warning... ad infinitum.

Good times :)

Used https://github.com/ross/requests-futures#working-in-the-background for hooks interface